### PR TITLE
REAR Data models extension for intent-based network border protection

### DIFF
--- a/models/examples/contract.json
+++ b/models/examples/contract.json
@@ -12,5 +12,6 @@
     "ExpirationTime": "2024-12-31T23:59:59Z",
     "Credentials": {
         "$ref": "credentials/liqo-credentials.schema.json"
-    }
+    },
+    "NetworkRequests": "configMap-14921"
 }

--- a/models/examples/flavor-types/k8slice.json
+++ b/models/examples/flavor-types/k8slice.json
@@ -21,6 +21,18 @@
         "carbonFootprint": {
             "embodied": 2000,
             "operational": []
+        },
+        "networkAuthorizations": {
+            "deniedCommunications": [
+                {
+                    "$ref": "intents/network-intent.json"
+                }
+            ],
+            "mandatoryCommunications": [
+                {
+                    "$ref": "intents/network-intent.json"
+                }
+            ]
         }
     },
     "policies": {

--- a/models/examples/intents/network-intent.json
+++ b/models/examples/intents/network-intent.json
@@ -1,0 +1,26 @@
+{
+    "name": "NetworkIntent1",
+    "source": {
+        "isHostCluster": true,
+        "resourceSelector": {
+            "pod": [
+                {
+                    "key": "app",
+                    "value": "*"
+                }
+            ],
+            "namespace": [
+                {
+                    "key": "env",
+                    "value": "production"
+                }
+            ]
+        }
+    },
+    "destination": {
+        "isHostCluster": false,
+        "resourceSelector": "10.0.0.0/16"
+    },
+    "destinationPort": "443",
+    "protocolType": "HTTPS"
+}

--- a/models/schemas/contract.schema.json
+++ b/models/schemas/contract.schema.json
@@ -26,6 +26,10 @@
         },
         "Credentials": {
             "$ref": "credentials/liqo-credentials.schema.json"
+        },
+        "NetworkRequests": {
+            "type": "string",
+            "description": "The name of the ConfigMap containing the network request intents"
         }
     }
 }

--- a/models/schemas/flavor-types/k8slice.schema.json
+++ b/models/schemas/flavor-types/k8slice.schema.json
@@ -81,6 +81,26 @@
                             "description": "Forecasted average carbon intensity of the node for the next N windows/hours."
                         }
                     }
+                },
+                "networkAuthorizations": {
+                    "type": "object",
+                    "description": "Network authorizations of the Flavor.",
+                    "properties": {
+                        "deniedCommunications": {
+                            "type": "array",
+                            "description": "List of denied communication.",
+                            "items": {
+                                "$ref": "../intents/networkIntent.json"
+                            }
+                        },
+                        "mandatoryCommunications": {
+                            "type": "array",
+                            "description": "List of mandatory communication (e.g., monitoring).",
+                            "items": {
+                                "$ref": "../intents/network-intent.schema.json"
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/models/schemas/intents/network-intent.schema.json
+++ b/models/schemas/intents/network-intent.schema.json
@@ -1,0 +1,128 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "title": "NetworkIntent",
+    "description": "Schema for representing an MSPL Network Intent.",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "The identifier of the network intent"
+        },
+        "source":  {
+            "type": "object",
+            "description": "The source of the communication",
+            "properties": {
+                "isHostCluster": {
+                    "type": "boolean",
+                    "description": "The source is in the host cluster"
+                },
+                "resourceSelector": {
+                    "description": "Selector for the source",
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "title": "podNamespaceSelector",
+                            "properties": {
+                                "pod": {
+                                    "type": "array",
+                                    "description": "one or many key-value pairs.",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "key": { "type": "string" },
+                                            "value": { "type": "string" }
+                                        }
+                                    },
+                                    "minItems": 1
+                                },
+                                "namespace": {
+                                    "type": "array",
+                                    "description": "one or many key-value pairs.",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "key": { "type": "string" },
+                                            "value": { "type": "string" }
+                                        }
+                                    },
+                                    "minItems": 1
+                                }
+                            }
+                        },
+                        {
+                            "title": "cidrSelector",
+                            "type": "string",
+                            "description": "CIDR range selector for the destination"
+                        }
+                    ]
+                }
+            }
+        },
+        "destination":  {
+            "type": "object",
+            "description": "The destination of the communication",
+            "properties": {
+                "isHostCluster": {
+                    "type": "boolean",
+                    "description": "The destination is in the host cluster"
+                },
+                "resourceSelector": {
+                    "description": "Selector for the destination",
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "title": "podNamespaceSelector",
+                            "properties": {
+                                "pod": {
+                                    "type": "array",
+                                    "description": "one or many key-value pairs.",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "key": { "type": "string" },
+                                            "value": { "type": "string" }
+                                        }
+                                    },
+                                    "minItems": 1
+                                },
+                                "namespace": {
+                                    "type": "array",
+                                    "description": "one or many key-value pairs.",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "key": { "type": "string" },
+                                            "value": { "type": "string" }
+                                        }
+                                    },
+                                    "minItems": 1
+                                }
+                            }
+                        },
+                        {
+                            "title": "cidrSelector",
+                            "type": "string",
+                            "description": "CIDR range selector for the destination"
+                        }
+                    ]
+                }
+            }
+        },
+        "destinationPort": {
+            "type": "string",
+            "description": "The destination port of the communication"
+        },
+        "protocolType": {
+            "type": "string",
+            "description": "The protocol type of the communication"
+        }
+    },
+    "required": [
+        "name",
+        "source",
+        "destination",
+        "destinationPort",
+        "protocolType"
+    ],
+    "additionalProperties": false
+}


### PR DESCRIPTION
Hello everyone,
This PR extends the REAR data model for the integration of the intent-based border protection solution for the network developed in WP5. The contributions are the following:

- Updated of the k8slice resource to include the advertisement of an associated set of network authorization properties.
- Added reference within the contract to a shared ConfigMaps that is used to comunicate the buyer's intents to the seller.

Thanks,
Francesco